### PR TITLE
rust: Cargo fmt

### DIFF
--- a/src/rsched_stats.rs
+++ b/src/rsched_stats.rs
@@ -868,7 +868,12 @@ impl RschedStats {
 
         for (group, mut cpus) in groups {
             cpus.sort();
-            println!("{}: CPUs ({}) {}", group.description(), cpus.len(), format_cpu_list(&cpus));
+            println!(
+                "{}: CPUs ({}) {}",
+                group.description(),
+                cpus.len(),
+                format_cpu_list(&cpus)
+            );
 
             // Show aggregate stats
             let mut total_hist = Hist::default();


### PR DESCRIPTION
Hi Chris,

This PR just applies `cargo fmt` to keep the codebase consistently formatted.

Would you be open to adding a lightweight CI workflow (e.g. GitHub Actions) that runs
`cargo fmt --check` (and maybe `cargo clippy -- -D warnings`) on every push/PR?
I can open a follow-up PR if that sounds useful.

Thanks!