### PR TITLE
rsched: fix verifier rejection of unbounded histogram slot access

### DIFF
--- a/src/bpf/rsched.bpf.c
+++ b/src/bpf/rsched.bpf.c
@@ -484,35 +484,37 @@ static __always_inline __u32 log2_slot(__u64 v)
  * - 10μs resolution for delays 0-499μs (covers most scheduling delays)
  * - Log2 scaling for larger delays up to ~134 seconds
  */
-static __always_inline __u32 hist_slot(__u64 delay_ns)
+/*
+ * __noinline forces a BPF subprogram call boundary so the compiler cannot
+ * prove the return value range and eliminate the callers' if (slot < MAX_SLOTS)
+ * bounds checks. Without this, __always_inline lets the compiler see that
+ * slot < MAX_SLOTS always holds, it removes every bounds check, and the BPF
+ * verifier (which cannot track ranges through division) rejects the program.
+ *
+ * Returns __u64 so the call site comparison operates directly on the 64-bit
+ * return register (r0) without a 32-bit truncation (<<32; >>32) that would
+ * break the verifier's register ID linkage between the bounds check and the
+ * subsequent array access.
+ */
+static __noinline __u64 hist_slot(__u64 delay_ns)
 {
 	__u64 delay_us = delay_ns / 1000;
+	__u64 slot;
 
 	if (delay_us < LINEAR_THRESHOLD) {
-		// Linear buckets: slot = delay_us / LINEAR_STEP
-		__u32 slot = delay_us / LINEAR_STEP;
-		return slot < LINEAR_SLOTS ? slot : LINEAR_SLOTS - 1;
+		slot = delay_us / LINEAR_STEP;
+		if (slot >= LINEAR_SLOTS)
+			slot = LINEAR_SLOTS - 1;
+	} else if (delay_us < 512) {
+		slot = LINEAR_SLOTS;
 	} else {
-		// Log2 buckets for values >= 500μs
-		// Find position of highest bit
-		__u32 log2_val = log2_u64(delay_us);
-
-		// log2(500) ≈ 8.97, but we'll map based on powers of 2
-		// Starting from 512μs (2^9) for cleaner boundaries
-		// This maps:
-		// 500-511μs → slot 50
-		// 512-1023μs → slot 50 (2^9 to 2^10-1)
-		// 1024-2047μs → slot 51 (2^10 to 2^11-1)
-		// etc.
-		if (delay_us < 512) {
-			return LINEAR_SLOTS; // slot 50 for 500-511μs
-		}
-
-		__u32 slot = LINEAR_SLOTS + (log2_val - 8);
-
-		// Cap at MAX_SLOTS - 1
-		return slot < MAX_SLOTS ? slot : MAX_SLOTS - 1;
+		__u64 log2_val = log2_u64(delay_us);
+		slot = LINEAR_SLOTS + (log2_val - 8);
+		if (slot >= MAX_SLOTS)
+			slot = MAX_SLOTS - 1;
 	}
+
+	return slot;
 }
 
 // sched_wakeup and sched_wakeup_new
@@ -575,7 +577,7 @@ check_sleep:
 				}
 
 				if (sleep_data) {
-					__u32 slot = hist_slot(sleep_duration);
+					__u64 slot = hist_slot(sleep_duration);
 					if (slot < MAX_SLOTS) {
 						__sync_fetch_and_add(
 							&sleep_data->hist
@@ -867,7 +869,7 @@ static __always_inline void update_timeslices(__u32 next_pid, __u32 prev_pid,
 	}
 
 	if (timeslice < 10000000000ULL) { // Skip > 10 seconds
-		__u32 slot = hist_slot(timeslice);
+		__u64 slot = hist_slot(timeslice);
 		if (slot < MAX_SLOTS) {
 			if (involuntary) {
 				// Involuntary context switch
@@ -893,7 +895,7 @@ update_queue_delay(__u32 next_pid, struct task_struct *next, __u64 now)
 {
 	__u64 *start_ts;
 	__u64 delay;
-	__u32 slot;
+	__u64 slot;
 	__u32 cpu;
 	struct hist_data *data;
 
@@ -945,7 +947,7 @@ update_waking_delay(__u32 next_pid, struct task_struct *next, __u64 now)
 {
 	__u64 *start_ts;
 	__u64 delay;
-	__u32 slot;
+	__u64 slot;
 
 	if (!trace_sched_waking)
 		return;
@@ -1002,7 +1004,7 @@ static __always_inline void update_cpu_idle(__u32 cpu, __u64 now)
 			}
 
 			if (cpu_idle_hist) {
-				__u32 slot = hist_slot(idle_duration);
+				__u64 slot = hist_slot(idle_duration);
 				if (slot < MAX_SLOTS) {
 					__sync_fetch_and_add(
 						&cpu_idle_hist->slots[slot], 1);


### PR DESCRIPTION
The BPF verifier rejects programs with "R0 unbounded memory access" because it cannot track value ranges through division. The compiler statically proves hist_slot() returns < MAX_SLOTS and eliminates all bounds checks, but the verifier sees an unbounded scalar after the division instruction and rejects the array access.

Two changes are needed to fix this:

Make hist_slot() __noinline to create a BPF subprogram call boundary. The compiler can no longer see through the call to prove the return value range, so the if (slot < MAX_SLOTS) checks at each call site survive into the emitted BPF where the verifier can track them.

Change hist_slot() return type and all call-site slot variables from __u32 to __u64. Without this, the compiler inserts a 32-bit truncation (<<32; >>32) between the return value and the bounds check, which breaks the verifier's register ID linkage -- it bounds one register via the comparison but uses the original unbounded register for the array offset.

tested on 6.14.0-1018-aws

also fix -g migration/most/all
